### PR TITLE
Hotfix/enums to "main"

### DIFF
--- a/app/Enum/RoleName.php
+++ b/app/Enum/RoleName.php
@@ -2,15 +2,12 @@
 
 namespace App\Enum;
 
-enum RoleName: string
-{
-    case ADMIN = 'Application Admin';
-    case USER = 'Application User';
+use Spatie\Enum\Enum;
 
-    public static function values(): array
-    {
-        return array_map(function ($enum) {
-            return $enum->value;
-        }, self::cases());
-    }
+/**
+ * @method static self admin()
+ * @method static self user()
+ */
+class RoleName extends Enum
+{
 }

--- a/app/Enum/UserRole.php
+++ b/app/Enum/UserRole.php
@@ -2,8 +2,19 @@
 
 namespace App\Enum;
 
-enum UserRole: int
+use Spatie\Enum\Enum;
+
+/**
+ * @method static self admin()
+ * @method static self user()
+ */
+class UserRole extends Enum
 {
-    case ADMIN = 1;
-    case USER = 2;
+    protected static function values(): array
+    {
+        return [
+            'admin' => 1,
+            'user' => 2,
+        ];
+    }
 }

--- a/app/Enum/UserStatus.php
+++ b/app/Enum/UserStatus.php
@@ -2,16 +2,13 @@
 
 namespace App\Enum;
 
-enum UserStatus: string
-{
-    case ACCEPTED = 'Accepted User';
-    case WARNED = 'Warned User';
-    case BANNED = 'Banned User';
+use Spatie\Enum\Enum;
 
-    public static function values(): array
-    {
-        return array_map(function ($enum) {
-            return $enum->value;
-        }, self::cases());
-    }
+/**
+ * @method static self accepted()
+ * @method static self warned()
+ * @method static self banned()
+ */
+class UserStatus extends Enum
+{
 }

--- a/app/Services/User/UserCreator.php
+++ b/app/Services/User/UserCreator.php
@@ -16,7 +16,7 @@ class UserCreator
     // Needs refactoring, photo upload.
     public function register(array $user): Response
     {
-        $user['role_id'] = UserRole::USER->value;
+        $user['role_id'] = UserRole::user()->value;
         $user['status'] = UserStatus::ACCEPTED->value;
         $user['date_of_birth'] = $this->formatDate($user['date_of_birth']);
         // $user['photo'] = file_get_contents($_FILES['photo']['tmp_name']);

--- a/app/Services/User/UserCreator.php
+++ b/app/Services/User/UserCreator.php
@@ -17,7 +17,7 @@ class UserCreator
     public function register(array $user): Response
     {
         $user['role_id'] = UserRole::user()->value;
-        $user['status'] = UserStatus::ACCEPTED->value;
+        $user['status'] = UserStatus::accepted()->value;
         $user['date_of_birth'] = $this->formatDate($user['date_of_birth']);
         // $user['photo'] = file_get_contents($_FILES['photo']['tmp_name']);
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "inertiajs/inertia-laravel": "^0.6.9",
         "laravel/framework": "^9.0",
         "laravel/sanctum": "^2.14",
-        "laravel/tinker": "^2.7"
+        "laravel/tinker": "^2.7",
+        "spatie/enum": "^3.13"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c343087cf05a3a963b8ea991cc9390f1",
+    "content-hash": "8f0d38cfef2f59925dcfc934df7b3267",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1184,16 +1184,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v9.52.10",
+            "version": "v9.52.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "858add225ce88a76c43aec0e7866288321ee0ee9"
+                "reference": "8bfd22be79f437fa335e70692e4e91ff40ce561d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/858add225ce88a76c43aec0e7866288321ee0ee9",
-                "reference": "858add225ce88a76c43aec0e7866288321ee0ee9",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/8bfd22be79f437fa335e70692e4e91ff40ce561d",
+                "reference": "8bfd22be79f437fa335e70692e4e91ff40ce561d",
                 "shasum": ""
             },
             "require": {
@@ -1378,7 +1378,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2023-06-27T13:25:54+00:00"
+            "time": "2023-07-26T13:20:55+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -1447,16 +1447,16 @@
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v1.3.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "f23fe9d4e95255dacee1bf3525e0810d1a1b0f37"
+                "reference": "e5a3057a5591e1cfe8183034b0203921abe2c902"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/f23fe9d4e95255dacee1bf3525e0810d1a1b0f37",
-                "reference": "f23fe9d4e95255dacee1bf3525e0810d1a1b0f37",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/e5a3057a5591e1cfe8183034b0203921abe2c902",
+                "reference": "e5a3057a5591e1cfe8183034b0203921abe2c902",
                 "shasum": ""
             },
             "require": {
@@ -1503,7 +1503,7 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2023-01-30T18:31:20+00:00"
+            "time": "2023-07-14T13:56:28+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -2901,16 +2901,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.11.18",
+            "version": "v0.11.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "4f00ee9e236fa6a48f4560d1300b9c961a70a7ec"
+                "reference": "1724ceff278daeeac5a006744633bacbb2dc4706"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4f00ee9e236fa6a48f4560d1300b9c961a70a7ec",
-                "reference": "4f00ee9e236fa6a48f4560d1300b9c961a70a7ec",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/1724ceff278daeeac5a006744633bacbb2dc4706",
+                "reference": "1724ceff278daeeac5a006744633bacbb2dc4706",
                 "shasum": ""
             },
             "require": {
@@ -2971,9 +2971,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.11.18"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.11.19"
             },
-            "time": "2023-05-23T02:31:11+00:00"
+            "time": "2023-07-15T19:42:19+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -3199,6 +3199,82 @@
                 }
             ],
             "time": "2023-04-15T23:01:58+00:00"
+        },
+        {
+            "name": "spatie/enum",
+            "version": "3.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/enum.git",
+                "reference": "f1a0f464ba909491a53e60a955ce84ad7cd93a2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/enum/zipball/f1a0f464ba909491a53e60a955ce84ad7cd93a2c",
+                "reference": "f1a0f464ba909491a53e60a955ce84ad7cd93a2c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.9.1",
+                "larapack/dd": "^1.1",
+                "phpunit/phpunit": "^9.0",
+                "vimeo/psalm": "^4.3"
+            },
+            "suggest": {
+                "fakerphp/faker": "To use the enum faker provider",
+                "phpunit/phpunit": "To use the enum assertions"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Enum\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brent Roose",
+                    "email": "brent@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Tom Witkowski",
+                    "email": "dev@gummibeer.de",
+                    "homepage": "https://gummibeer.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Enums",
+            "homepage": "https://github.com/spatie/enum",
+            "keywords": [
+                "enum",
+                "enumerable",
+                "spatie"
+            ],
+            "support": {
+                "docs": "https://docs.spatie.be/enum",
+                "issues": "https://github.com/spatie/enum/issues",
+                "source": "https://github.com/spatie/enum"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-04-22T08:51:55+00:00"
         },
         {
             "name": "symfony/console",
@@ -5854,16 +5930,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.15.2",
+            "version": "2.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "aac9304c5ed61bf7b1b7a6064bf9806ab842ce73"
+                "reference": "c83e88a30524f9360b11f585f71e6b17313b7187"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/aac9304c5ed61bf7b1b7a6064bf9806ab842ce73",
-                "reference": "aac9304c5ed61bf7b1b7a6064bf9806ab842ce73",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/c83e88a30524f9360b11f585f71e6b17313b7187",
+                "reference": "c83e88a30524f9360b11f585f71e6b17313b7187",
                 "shasum": ""
             },
             "require": {
@@ -5913,7 +5989,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.15.2"
+                "source": "https://github.com/filp/whoops/tree/2.15.3"
             },
             "funding": [
                 {
@@ -5921,7 +5997,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-12T12:00:00+00:00"
+            "time": "2023-07-13T12:00:00+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -6041,37 +6117,33 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.6.2",
+            "version": "1.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "13a7fa2642c76c58fa2806ef7f565344c817a191"
+                "reference": "d1413755e26fe56a63455f7753221c86cbb88f66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/13a7fa2642c76c58fa2806ef7f565344c817a191",
-                "reference": "13a7fa2642c76c58fa2806ef7f565344c817a191",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/d1413755e26fe56a63455f7753221c86cbb88f66",
+                "reference": "d1413755e26fe56a63455f7753221c86cbb88f66",
                 "shasum": ""
             },
             "require": {
                 "hamcrest/hamcrest-php": "^2.0.1",
                 "lib-pcre": ">=7.0",
-                "php": "^7.4 || ^8.0"
+                "php": ">=7.4,<8.3"
             },
             "conflict": {
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.5 || ^9.3",
-                "psalm/plugin-phpunit": "^0.18",
-                "vimeo/psalm": "^5.9"
+                "psalm/plugin-phpunit": "^0.18.4",
+                "symplify/easy-coding-standard": "^11.5.0",
+                "vimeo/psalm": "^5.13.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.6.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "library/helpers.php",
@@ -6089,12 +6161,20 @@
                 {
                     "name": "Pádraic Brady",
                     "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
                 },
                 {
                     "name": "Dave Marshall",
                     "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "http://davedevelopment.co.uk"
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
                 }
             ],
             "description": "Mockery is a simple yet flexible PHP mock object framework",
@@ -6112,10 +6192,13 @@
                 "testing"
             ],
             "support": {
+                "docs": "https://docs.mockery.io/",
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.6.2"
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
             },
-            "time": "2023-06-07T09:07:52+00:00"
+            "time": "2023-07-19T15:51:02+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -6377,16 +6460,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.26",
+            "version": "9.2.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
+                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
-                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b0a88255cb70d52653d80c890bd7f38740ea50d1",
+                "reference": "b0a88255cb70d52653d80c890bd7f38740ea50d1",
                 "shasum": ""
             },
             "require": {
@@ -6442,7 +6525,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.27"
             },
             "funding": [
                 {
@@ -6450,7 +6534,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T12:58:08+00:00"
+            "time": "2023-07-26T13:44:30+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",

--- a/database/factories/AdminFactory.php
+++ b/database/factories/AdminFactory.php
@@ -10,7 +10,7 @@ class AdminFactory extends Factory
     public function definition(): array
     {
         return [
-            'role_id' => UserRole::ADMIN->value,
+            'role_id' => UserRole::admin()->value,
             'email' => fake()->safeEmail(),
             'password' => bcrypt('password'),
         ];

--- a/database/factories/RoleFactory.php
+++ b/database/factories/RoleFactory.php
@@ -10,7 +10,7 @@ class RoleFactory extends Factory
     public function definition(): array
     {
         return [
-            'role_name' => fake()->randomElement(RoleName::values()),
+            'role_name' => fake()->randomElement(RoleName::toValues()),
         ];
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -11,7 +11,7 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'role_id' => UserRole::USER->value,
+            'role_id' => UserRole::user()->value,
             'first_name' => fake()->firstName(),
             'last_name' => fake()->lastName(),
             'email' => fake()->unique()->safeEmail(),

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -19,7 +19,7 @@ class UserFactory extends Factory
             'photo' => base64_encode('photo'),
             'emergency_contact_name' => fake()->name(),
             'emergency_contact_number' => fake()->phoneNumber(),
-            'status' => fake()->randomElement(UserStatus::cases()),
+            'status' => fake()->randomElement(UserStatus::toValues()),
             'fee' => fake()->randomElement([5, 10]),
         ];
     }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -14,13 +14,13 @@ class RoleSeeder extends Seeder
         Role::factory()
             ->create([
                 'id' => UserRole::ADMIN->value,
-                'role_name' => RoleName::ADMIN->value,
+                'role_name' => RoleName::admin()->value,
             ]);
 
         Role::factory()
             ->create([
                 'id' => UserRole::USER->value,
-                'role_name' => RoleName::USER->value,
+                'role_name' => RoleName::user()->value,
             ]);
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -13,13 +13,13 @@ class RoleSeeder extends Seeder
     {
         Role::factory()
             ->create([
-                'id' => UserRole::ADMIN->value,
+                'id' => UserRole::admin()->value,
                 'role_name' => RoleName::admin()->value,
             ]);
 
         Role::factory()
             ->create([
-                'id' => UserRole::USER->value,
+                'id' => UserRole::user()->value,
                 'role_name' => RoleName::user()->value,
             ]);
     }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -14,13 +14,13 @@ class UserSeeder extends Seeder
     {
         Admin::factory(2)
             ->create([
-                'role_id' => UserRole::ADMIN->value,
+                'role_id' => UserRole::admin()->value,
             ]);
 
         User::factory(10)
             ->has(CheckIn::factory())
             ->create([
-                'role_id' => UserRole::USER->value,
+                'role_id' => UserRole::user()->value,
             ]);
     }
 }


### PR DESCRIPTION
We had to do a last minute adjustment, since our project is being host with "Hostinger" we did not took into account the php versioning on those servers, development went with php ^8.1, however the server stands until php 8.0, this cause a problem.

The application holds Enums at code level, however migrations, seeding, or faking data was not supported on production due to this incident; enums are a native feature of php core since ^8.1 versions.

To give a possible solution on this branch we installed and used "Spaties" library called "Enums". We did:

<composer require spatie/enums>

And downgrade all implementations of 8.1 php enums native version, to spatie's enums library so it can be used with php:8.0 that its the one version running on the server at the moment, whenever possible, once the server has been updated to a new version of php, we will upgrade the whole application possibly to Laravel ^10 version.  