### PR TITLE
"Hotfix/no-daypass-error"

### DIFF
--- a/app/Services/Reservation/ReservationCreator.php
+++ b/app/Services/Reservation/ReservationCreator.php
@@ -94,19 +94,28 @@ class ReservationCreator
     private function redirect(?array $data = []): Response
     {
         if ($data) {
-            if ($this->isReservationToday($data['date'])) {
-                return Inertia::render('User/DayPass', [
-                    'user' => $data['user'],
-                    'date' => $data['date'],
-                    'localeText' => $this->dayPassText(),
+            $reservationTime = $this->isReservationToday($data['date']);
 
-                ]);
-            } else {
-                return Inertia::render('User/NoDayPass', [
-                    'email' => $data['user']['email'],
-                    'localeText' => $this->noDayPassText(),
-                    'date' => $data['date'],
-                ]);
+            switch ($reservationTime) {
+                case 'yesterday':
+                    return Inertia::render('Index', [
+                        'localeText' => $this->indexText(),
+                    ]);
+                    break;
+                case 'today':
+                    return Inertia::render('User/DayPass', [
+                        'user' => $data['user'],
+                        'date' => $data['date'],
+                        'localeText' => $this->dayPassText(),
+                    ]);
+                    break;
+                case 'future':
+                    return Inertia::render('User/NoDayPass', [
+                        'email' => $data['user']['email'],
+                        'localeText' => $this->noDayPassText(),
+                        'date' => $data['date'],
+                    ]);
+                    break;
             }
         } else {
             return Inertia::render('Index', [

--- a/app/Services/ServiceHelper.php
+++ b/app/Services/ServiceHelper.php
@@ -37,16 +37,23 @@ trait ServiceHelper
         return User::where('email', $email)->pluck('id')->first();
     }
 
-    protected function isReservationToday(string $rawDate): bool
+    protected function isReservationToday(string $rawDate): string
     {
+        $when = '';
+        $today =  date('d-m-Y');
         $date = strtotime($rawDate);
         $date = date('d-m-Y', $date);
 
-        if ($date === date('d-m-Y')) {
-            return true;
+
+        if ($date < $today) {
+            $when = 'yesterday';
+        } else if ($date === $today) {
+            $when = 'today';
         } else {
-            return false;
+            $when = 'future';
         }
+
+        return $when;
     }
 
     protected function firstLetterToUpperCase(string $string): string

--- a/resources/js/Pages/User/Reservation.jsx
+++ b/resources/js/Pages/User/Reservation.jsx
@@ -18,7 +18,7 @@ const Reservation = ({ localeText }) => {
   const [email, setEmail] = useState('');
   const [date, setDate] = useState(null);
 
-  const startDate = new Date('2023-09-04');
+  const startDate = new Date('2023-10-08'); // normally start on a monday
 
   const addDays = (date, days) => {
     let result = new Date(date);
@@ -71,14 +71,15 @@ const Reservation = ({ localeText }) => {
               onDateChange={handleDateChange}
               includeDays={[
                 startDate,
-                addDays(startDate, 6),
-                addDays(startDate, 7),
-                addDays(startDate, 13),
-                addDays(startDate, 14),
-                addDays(startDate, 20),
-                addDays(startDate, 21),
-                addDays(startDate, 27),
-                addDays(startDate, 28)
+                // Next you'll find comments on set only weekends on a month
+                addDays(startDate, 1),  // 6  | 1  |
+                addDays(startDate, 7),  // 7  | 7  |
+                addDays(startDate, 8),  // 13 | 8  |
+                addDays(startDate, 14), // 14 | 14 |
+                addDays(startDate, 15), // 20 | 15 |
+                addDays(startDate, 21), // 21 | 21 |
+                addDays(startDate, 22), // 27 | 22 |
+                // addDays(startDate, 28)// 28 | c
               ]}
             />
           </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,9 +17,7 @@ Route::middleware(['locale'])->group(function () {
     Route::post('reservation-d', [ReservationController::class, 'destroy']);
 
     Route::get('check-in', [ReservationController::class, 'toCheckIn']);
-    Route::post('check-in', [ReservationController::class, 'checkReservation']);
-
-    Route::get('day-pass', [ReservationController::class, 'toDayPass']);
+    Route::post('check-in', [ReservationController::class, 'toDayPass']);
 
     Route::get('language', [LocaleController::class, 'show']);
     Route::post('language', [LocaleController::class, 'change']);


### PR DESCRIPTION
Normally when you click on check in and if your reservation is due for today it will show you the `Daypass` web page however there was a bug where if you stay on that page and waited one day and then reload, the app would not know what to do with your request so it will think that is still active and since it is not due the same date as the user reload the page it will show the `No-Daypass` site on which the reservation can be deleted.

So on this branch what I did was to delete the `daypass` site as a get route and updated the logic on how to access the page and made a verification process through a helper to return on which date the current reservation being manipulated is due, if it has already pass it will redirect the user to the index after reload, covering the test case on what would happen in the scenario mentioned above, fixing the issue.